### PR TITLE
AILZ80ASM.jsonの処理部分を強化

### DIFF
--- a/AILZ80ASM.Test/CommandLineTest.cs
+++ b/AILZ80ASM.Test/CommandLineTest.cs
@@ -250,7 +250,7 @@ namespace AILZ80ASM.Test
                 Assert.AreEqual(rootCommand.GetValue<FileInfo>("outputBin").Name, "Test.bin");
                 Assert.IsFalse(rootCommand.GetSelected("output"));
                 Assert.IsFalse(rootCommand.GetSelected("outputMode"));
-                
+
                 var outputFiles = rootCommand.GetOutputFiles();
                 Assert.AreEqual(outputFiles.Count, 1);
                 Assert.AreEqual(outputFiles[AsmEnum.FileTypeEnum.BIN].Name, "Test.bin");
@@ -800,7 +800,8 @@ namespace AILZ80ASM.Test
         {
             var rootCommand = AsmCommandLine.SettingRootCommand();
 
-            Assert.ThrowsException<Exception>(() => {
+            Assert.ThrowsException<Exception>(() =>
+            {
                 rootCommand.AddOption(new CommandLine.Option<FileInfo[]>()
                 {
                     Name = "input",
@@ -813,7 +814,8 @@ namespace AILZ80ASM.Test
                 });
             });
 
-            Assert.ThrowsException<Exception>(() => {
+            Assert.ThrowsException<Exception>(() =>
+            {
                 rootCommand.AddOption(new CommandLine.Option<FileInfo[]>()
                 {
                     Name = "input_test",
@@ -827,6 +829,101 @@ namespace AILZ80ASM.Test
             });
         }
 
+        [TestMethod]
+        public void Test_ParseArgumentsFromJsonString()
+        {
+            {
+                var testJson = @"
+{
+  ""default-options"": [
+    ""-err""
+  ],
+  ""disable-warnings"": [
+    ""W0001"",
+    ""W9001"",
+    ""W9002""
+  ]
+}";
+                var argments = AsmCommandLine.ParseArgumentsFromJsonString(testJson);
+                Assert.AreEqual(argments[0], "-err");
+                Assert.AreEqual(argments[1], "-dw");
+                Assert.AreEqual(argments[2], "W0001");
+                Assert.AreEqual(argments[3], "W9001");
+                Assert.AreEqual(argments[4], "W9002");
+            }
 
+            {
+                 var testJson = @"
+{
+  ""default-options"": [
+    ""-ts 8""
+  ],
+  ""disable-warnings"": [
+    ""W0001"",
+    ""W9001"",
+    ""W9002""
+  ]
+}";
+                var argments = AsmCommandLine.ParseArgumentsFromJsonString(testJson);
+                Assert.AreEqual(argments[0], "-ts");
+                Assert.AreEqual(argments[1], "8");
+                Assert.AreEqual(argments[2], "-dw");
+                Assert.AreEqual(argments[3], "W0001");
+                Assert.AreEqual(argments[4], "W9001");
+                Assert.AreEqual(argments[5], "W9002");
+            }
+
+            {
+                var testJson = @"
+{
+  ""default-options"": [
+    ""-ts 8""
+  ],
+  ""disable-warnings"": [
+    ""W0001"",
+    ""W9001"",
+    ""W9002"",
+  ]
+}";
+                var argments = AsmCommandLine.ParseArgumentsFromJsonString(testJson);
+                Assert.AreEqual(argments[0], "-ts");
+                Assert.AreEqual(argments[1], "8");
+                Assert.AreEqual(argments[2], "-dw");
+                Assert.AreEqual(argments[3], "W0001");
+                Assert.AreEqual(argments[4], "W9001");
+                Assert.AreEqual(argments[5], "W9002");
+            }
+
+            {
+                var testJson = @"
+{
+  ""default-options"": [
+    ""-ts 8"",
+  ],
+  ""disable-warnings"": [
+    ""W0001"",
+    ""W9001""
+    ""W9002"",
+  ]
+}";
+                try
+                {
+                    try
+                    {
+                        var argments = AsmCommandLine.ParseArgumentsFromJsonString(testJson);
+                        Assert.Fail();
+                    }
+                    catch (System.Text.Json.JsonException ex)
+                    {
+                        throw new Exception($"{ex.LineNumber}行目に問題があります。");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Assert.AreEqual(ex.Message, "8行目に問題があります。");
+                }
+
+            }
+        }
     }
 }

--- a/AILZ80ASM/Assembler/AsmCommandLine.cs
+++ b/AILZ80ASM/Assembler/AsmCommandLine.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
@@ -532,6 +533,26 @@ namespace AILZ80ASM.Assembler
                     return readme;
                 }
             }
+        }
+
+        /// <summary>
+        /// JsonからArgumentsのパースを行う
+        /// </summary>
+        /// <param name="profileString"></param>
+        /// <returns></returns>
+        public static IList<string> ParseArgumentsFromJsonString(string profileString)
+        {
+            var options = new JsonSerializerOptions { AllowTrailingCommas = true };
+            var defaultProfile = JsonSerializer.Deserialize<AILZ80ASM.Models.Profile>(profileString, options);
+            var profileArguments = new List<string>();
+            profileArguments.AddRange(defaultProfile.DefaultOptions.SelectMany(m => m.Split(' ')).Where(m => !string.IsNullOrEmpty(m)));
+            if (defaultProfile.DisableWarnings != default && defaultProfile.DisableWarnings.Count() > 0)
+            {
+                profileArguments.Add("-dw");
+                profileArguments.AddRange(defaultProfile.DisableWarnings);
+            }
+
+            return profileArguments;
         }
 
     }

--- a/AILZ80ASM/Program.cs
+++ b/AILZ80ASM/Program.cs
@@ -30,18 +30,19 @@ namespace AILZ80ASM
                     var profilePath = Path.Combine(processDirectory, PROFILE_FILENAME);
                     if (File.Exists(profilePath))
                     {
-                        var defaultProfile = JsonSerializer.Deserialize<AILZ80ASM.Models.Profile>(File.ReadAllText(profilePath));
-                        var profileArguments = new List<string>();
-                        profileArguments.AddRange(defaultProfile.DefaultOptions);
-                        if (defaultProfile.DisableWarnings != default && defaultProfile.DisableWarnings.Count() > 0)
-                        {
-                            profileArguments.Add("-dw");
-                            profileArguments.AddRange(defaultProfile.DisableWarnings);
-                        }
+                        var profileString = File.ReadAllText(profilePath);
+                        var profileArguments = AsmCommandLine.ParseArgumentsFromJsonString(profileString);
                         args = args.Concat(profileArguments).ToArray();
                     }
                 }
-                catch { }
+                catch (System.Text.Json.JsonException ex)
+                {
+                    throw new Exception($"{PROFILE_FILENAME}:{ex.LineNumber}行目に問題があります。");
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception($"{PROFILE_FILENAME}:{ex.Message}", ex);
+                }
 
                 // コマンドラインの設定をする
                 var rootCommand = AsmCommandLine.SettingRootCommand();
@@ -266,47 +267,5 @@ namespace AILZ80ASM
             Trace.WriteLine("");
         }
 
-        /*
-        private static void OutputStartForDebug(FileInfo fileInfo)
-        {
-            Trace.WriteLine(ProductInfo.ProductLongName);
-            Trace.WriteLine(ProductInfo.Copyright);
-            Trace.WriteLine("");
-            //OutputDebug(new[] { ProductInfo.ProductLongName, ProductInfo.Copyright, $"Assemble start:{DateTime.Now}", "" }, fileInfo, false);
-        }
-
-        private static void OutputFileList(Dictionary<AsmEnum.FileTypeEnum, FileInfo> outputFiles)
-        {
-            foreach (var outputFile in outputFiles)
-            {
-                Trace.WriteLine($"{outputFile.Value.Name}");
-            }
-        }
-
-        private static void OutputDebug(string[] targets, FileInfo fileInfo)
-        {
-            //OutputDebug(targets, fileInfo, true);
-        }
-
-        private static void DebugWriteLine(string[] targets, FileInfo fileInfo, bool display)
-        {
-            if (fileInfo == default)
-            {
-                return;
-            }
-
-            using (var streamWriter = fileInfo.AppendText())
-            {
-                foreach (var item in targets)
-                {
-                    if (display)
-                    {
-                        Trace.WriteLine(item);
-                    }
-                    streamWriter.WriteLine(item);
-                }
-            }
-        }
-        */
     }
 }


### PR DESCRIPTION
- Jsonのパース時に、最終行の「,」が存在していても問題ないように変更
- コマンドラインオプションの設定時「-ts 8」のような記述を許可