### PR TITLE
[issues-291] CHECK ALIGNのエラーメッセージの範囲記号をマイナス記号に変更する

### DIFF
--- a/AILZ80ASM.Test/AILZ80ASM.Test.csproj
+++ b/AILZ80ASM.Test/AILZ80ASM.Test.csproj
@@ -133,6 +133,9 @@
     <None Update="Test\Issues\222\Test.Z80">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Test\Issues\291\Test.ERR">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Test\Issues\231\Test.BIN">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -239,6 +242,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Test\Issues\276\Test.Z80">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Test\Issues\291\Test.LST">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Test\Issues\291\Test.Z80">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Test\TestCS_ALIGN\Test.BIN">

--- a/AILZ80ASM.Test/Test/Issues/291/Test.ERR
+++ b/AILZ80ASM.Test/Test/Issues/291/Test.ERR
@@ -1,0 +1,31 @@
+﻿*** AILZ80ASM *** Z-80 Assembler, version 1.0.15.0
+Copyright (C) 2023 by M.Ishino (AILight)
+
+# Inputs
+
+- Z80 filename [Test.Z80]
+
+# Assemble Status
+
+- Expand       (1/6)
+- PreAssemble  (2/6)
+- AdjAssemble  (3/6)
+- MainAssemble (4/6)
+- Validate     (5/6)
+- Complete     (6/6)
+
+# Outputs
+
+- LST filename [Issue291.LST]: Successful
+- BIN filename [Issue291.bin]: Failed
+
+# Error
+
+Test.Z80:9  E6012: CHECK ALIGN メモリ境界を超えました。アライメント境界:0x100 - 0x1FF 出力アドレス:0x1FF - 0x203
+
+# List
+
+Issue291.LST:10  E6012: CHECK ALIGN メモリ境界を超えました。アライメント境界:0x100 - 0x1FF 出力アドレス:0x1FF - 0x203
+
+1 error(s), 0 warning(s), 0 information
+

--- a/AILZ80ASM.Test/Test/Issues/291/Test.LST
+++ b/AILZ80ASM.Test/Test/Issues/291/Test.LST
@@ -1,0 +1,13 @@
+﻿                                ;*** AILZ80ASM *** Z-80 Assembler, version 1.0.8.0, LST:Full:4
+000000 0100                         org 0x100
+                                
+                                    CHECK ALIGN 256
+000000 0100 0001020304              DB 0, 1, 2, 3 ,4
+                                    ENDC
+                                
+0000FF 01FF                         org 0x1FF
+                                
+            **** E6012 ****         CHECK ALIGN 256
+0000FF 01FF 0001020304              DB 0, 1, 2, 3 ,4
+                                    ENDC
+[EOF:Test.Z80:UTF_8]

--- a/AILZ80ASM.Test/Test/Issues/291/Test.Z80
+++ b/AILZ80ASM.Test/Test/Issues/291/Test.Z80
@@ -1,0 +1,11 @@
+﻿    org 0x100
+
+    CHECK ALIGN 256
+    DB 0, 1, 2, 3 ,4
+    ENDC
+
+    org 0x1FF
+
+    CHECK ALIGN 256
+    DB 0, 1, 2, 3 ,4
+    ENDC

--- a/AILZ80ASM.Test/Z80ZZIssueTest.cs
+++ b/AILZ80ASM.Test/Z80ZZIssueTest.cs
@@ -211,5 +211,14 @@ namespace AILZ80ASM.Test
         {
             Lib.Assemble_AreSame(Path.Combine("Issues", "281"));
         }
+
+        [TestMethod]
+        public void Issue_291()
+        {
+            var result = Program.Main(@"Test.Z80", "-f", "-bin", "Issue291.bin", "-lst", "Issue291.LST", "-err", "Issue291.ERR", "-cd", "./Test/Issues/291");
+            Assert.AreEqual(1, result);
+            Lib.AreSameLst(File.OpenRead("./Test/Issues/291/Issue291.LST"), File.OpenRead("./Test/Issues/291/Test.LST"), Assembler.AsmEnum.FileTypeEnum.LST);
+            Lib.AreSameLst(File.OpenRead("./Test/Issues/291/Issue291.ERR"), File.OpenRead("./Test/Issues/291/Test.ERR"), Assembler.AsmEnum.FileTypeEnum.ERR);
+        }
     }
 }

--- a/AILZ80ASM/Assembler/Error.cs
+++ b/AILZ80ASM/Assembler/Error.cs
@@ -261,7 +261,7 @@ namespace AILZ80ASM.Assembler
             // CHECK
             [ErrorCodeEnum.E6001] = "ENDC が先に見つかりました。",
             [ErrorCodeEnum.E6011] = "CHECK ALIGN に対応する ENDC が見つかりませんでした。",
-            [ErrorCodeEnum.E6012] = "CHECK ALIGN メモリ境界を超えました。アライメント境界:0x{0:X} ~ 0x{1:X} 出力アドレス:0x{2:X} ~ 0x{3:X}",
+            [ErrorCodeEnum.E6012] = "CHECK ALIGN メモリ境界を超えました。アライメント境界:0x{0:X} - 0x{1:X} 出力アドレス:0x{2:X} - 0x{3:X}",
             [ErrorCodeEnum.E6013] = "CHECK ALIGNに指定したアドレスは、2のべき乗である必要があります。",
 
             // ENUM


### PR DESCRIPTION
## チケット
[[issues-291] CHECK ALIGNのエラーメッセージの範囲記号をマイナス記号に変更する](https://github.com/AILight/AILZ80ASM/issues/291)

## 対応方法
- エラーメッセージ中の ~ を - に変更した
