### PR TITLE
正規表現をコンパイル済みみして高速化

### DIFF
--- a/AILZ80ASM/AILight/AIName.cs
+++ b/AILZ80ASM/AILight/AIName.cs
@@ -9,12 +9,33 @@ namespace AILZ80ASM.AILight
     public static class AIName
     {
         private static readonly string RegexPatternLabelValidate = @"^[a-zA-Z0-9_]+$";
+        private static readonly Regex CompiledRegexPatternLabelValidate = new Regex(
+            RegexPatternLabelValidate, RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternMacroValidate = @"^[a-zA-Z0-9_()]+$";
+        private static readonly Regex CompiledRegexPatternMacroValidate = new Regex(
+            RegexPatternMacroValidate, RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternLocalLabelNOValidate = @"^[a-zA-Z0-9_]+$";
+        private static readonly Regex CompiledRegexPatternLocalLabelNOValidate = new Regex(
+            RegexPatternLocalLabelNOValidate, RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternLocalLabelATValidate = @"^@[0-9]+$";
+        private static readonly Regex CompiledRegexPatternLocalLabelATValidate = new Regex(
+            RegexPatternLocalLabelATValidate, RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternLocalLabelANValidate = @"^@@(?<labelValue>([0-9]*))$";
+        private static readonly Regex CompiledRegexPatternLocalLabelANValidate = new Regex(
+            RegexPatternLocalLabelANValidate, RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternLabelInvalid = @"^[0-9]";
+        private static readonly Regex CompiledRegexPatternLabelInvalid = new Regex(
+            RegexPatternLabelInvalid, RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternCharMapInvalid = @"^@[a-zA-Z0-9_]+$";
+        private static readonly Regex CompiledRegexPatternCharMapInvalid = new Regex(
+            RegexPatternCharMapInvalid, RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
 
         public static bool DeclareLabelValidate(string target, AsmLoad asmLoad)
         {
@@ -296,7 +317,7 @@ namespace AILZ80ASM.AILight
                 return false;
             }
 
-            return Regex.Match(target, RegexPatternCharMapInvalid, RegexOptions.Singleline | RegexOptions.IgnoreCase).Success;
+            return CompiledRegexPatternCharMapInvalid.Match(target).Success;
         }
 
         /// <summary>
@@ -343,8 +364,8 @@ namespace AILZ80ASM.AILight
                 return false;
             }
 
-            return  Regex.Match(target, RegexPatternLabelValidate, RegexOptions.Singleline | RegexOptions.IgnoreCase).Success &&
-                   !Regex.Match(target, RegexPatternLabelInvalid,  RegexOptions.Singleline | RegexOptions.IgnoreCase).Success;
+            return CompiledRegexPatternLabelValidate.Match(target).Success &&
+                   !CompiledRegexPatternLabelInvalid.Match(target).Success;
         }
 
         /// <summary>
@@ -381,8 +402,8 @@ namespace AILZ80ASM.AILight
                 return false;
             }
 
-            return  Regex.Match(target, RegexPatternMacroValidate, RegexOptions.Singleline | RegexOptions.IgnoreCase).Success &&
-                   !Regex.Match(target, RegexPatternLabelInvalid, RegexOptions.Singleline | RegexOptions.IgnoreCase).Success;
+            return CompiledRegexPatternMacroValidate.Match(target).Success &&
+                   !CompiledRegexPatternLabelInvalid.Match(target).Success;
         }
 
         private static bool ValidateNameForLocalLabel(string target, AsmLoad asmLoad)
@@ -398,7 +419,7 @@ namespace AILZ80ASM.AILight
                 return false;
             }
 
-            var regex = Regex.Match(target, RegexPatternLocalLabelANValidate, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            var regex = CompiledRegexPatternLocalLabelANValidate.Match(target);
             if (regex.Success)
             {
                 var valueString= regex.Groups["labelValue"].Value;
@@ -416,8 +437,8 @@ namespace AILZ80ASM.AILight
             }
 
             // @と通常ラベルの処理
-            return Regex.Match(target, RegexPatternLocalLabelATValidate, RegexOptions.Singleline | RegexOptions.IgnoreCase).Success ||
-                   Regex.Match(target, RegexPatternLocalLabelNOValidate, RegexOptions.Singleline | RegexOptions.IgnoreCase).Success;
+            return CompiledRegexPatternLocalLabelATValidate.Match(target).Success ||
+                   CompiledRegexPatternLocalLabelNOValidate.Match(target).Success;
         }
 
         /// <summary>
@@ -444,8 +465,8 @@ namespace AILZ80ASM.AILight
                 return false;
             }
 
-            return Regex.Match(target, RegexPatternLabelValidate, RegexOptions.Singleline | RegexOptions.IgnoreCase).Success &&
-                   !Regex.Match(target, RegexPatternLabelInvalid, RegexOptions.Singleline | RegexOptions.IgnoreCase).Success;
+            return CompiledRegexPatternLabelValidate.Match(target).Success &&
+                   !CompiledRegexPatternLabelInvalid.Match(target).Success;
         }
 
         /// <summary>
@@ -472,8 +493,8 @@ namespace AILZ80ASM.AILight
                 return false;
             }
 
-            return Regex.Match(target, RegexPatternLabelValidate, RegexOptions.Singleline | RegexOptions.IgnoreCase).Success &&
-                   !Regex.Match(target, RegexPatternLabelInvalid, RegexOptions.Singleline | RegexOptions.IgnoreCase).Success;
+            return CompiledRegexPatternLabelValidate.Match(target).Success &&
+                   !CompiledRegexPatternLabelInvalid.Match(target).Success;
         }
 
     }

--- a/AILZ80ASM/AILight/AIValue.cs
+++ b/AILZ80ASM/AILight/AIValue.cs
@@ -234,32 +234,85 @@ namespace AILZ80ASM.AILight
         /// オペレーション判別・正規表現用
         /// </summary>
         private static readonly string RegexPatternOperation = $"^(?<operation>({OperationKeysString}))";
+        private static readonly Regex CompiledRegexPatternOperation = new Regex(
+            RegexPatternOperation, RegexOptions.Compiled | RegexOptions.IgnoreCase
+        );
 
         /// <summary>
         /// オペレーション判別・正規表現用（文字列のみ）
         /// </summary>
         private static readonly string RegexPatternWordOperation = $"^(?<operation>({WordOperationKeysString}))";
+        private static readonly Regex CompiledRegexPatternWordOperation = new Regex(
+            RegexPatternWordOperation, RegexOptions.Compiled | RegexOptions.IgnoreCase
+        );
 
         /// <summary>
         /// オペレーション判別・正規表現用（記号のみ）
         /// </summary>
         private static readonly string RegexPatternSymbolOperation = $"^(?<operation>({SymbolOperationKeysString}))";
+        private static readonly Regex CompiledRegexPatternSymbolOperation = new Regex(
+            RegexPatternSymbolOperation, RegexOptions.Compiled | RegexOptions.IgnoreCase
+        );
 
         private static readonly string RegexPatternHexadecimal_HD = @"^\$(?<value>([0-9A-Fa-f]+))$";
+        private static readonly Regex CompiledRegexPatternHexadecimal_HD = new Regex(
+            RegexPatternHexadecimal_HD, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
+
         private static readonly string RegexPatternHexadecimal_HX = @"^0x(?<value>([0-9A-Fa-f]+))$";
+        private static readonly Regex CompiledRegexPatternHexadecimal_HX = new Regex(
+            RegexPatternHexadecimal_HX, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
+
         private static readonly string RegexPatternHexadecimal_TH = @"^(?<value>([0-9A-Fa-f]+))H$";
+        private static readonly Regex CompiledRegexPatternHexadecimal_TH = new Regex(
+            RegexPatternHexadecimal_TH, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
 
         private static readonly string RegexPatternOctal_HO = @"^0o(?<value>([0-7]+))$";
+        private static readonly Regex CompiledRegexPatternOctal_HO = new Regex(
+            RegexPatternOctal_HO, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternOctal_TO = @"^(?<value>([0-7]+))O$";
+        private static readonly Regex CompiledRegexPatternOctal_TO = new Regex(
+            RegexPatternOctal_TO, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternBinaryNumber_HB = @"^0b(?<value>([01_]+))$";
+        private static readonly Regex CompiledRegexPatternBinaryNumber_HB = new Regex(
+            RegexPatternBinaryNumber_HB, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternBinaryNumber_TB = @"^(?<value>([01_]+))B$";
+        private static readonly Regex CompiledRegexPatternBinaryNumber_TB = new Regex(
+            RegexPatternBinaryNumber_TB, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternBinaryNumber_HP = @"^%(?<value>([01_]+))$";
+        private static readonly Regex CompiledRegexPatternBinaryNumber_HP = new Regex(
+            RegexPatternBinaryNumber_HP, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternDigit_N = @"^(?<value>(\+|\-|)(\d+))$";
+        private static readonly Regex CompiledRegexPatternDigit_N = new Regex(
+            RegexPatternDigit_N, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternDigit_D = @"^(?<value>(\+|\-|)(\d+))D$";
+        private static readonly Regex CompiledRegexPatternDigit_D = new Regex(
+            RegexPatternDigit_D, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternValue = @"^(?<value>[0-9a-zA-Z_\$#@\.]+)";
+        private static readonly Regex CompiledRegexPatternValue = new Regex(
+            RegexPatternValue, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternFunction = @"^(?<function>[0-9a-zA-Z_]+\s*\()";
+        private static readonly Regex CompiledRegexPatternFunction = new Regex(
+            RegexPatternFunction, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternFunctionWithNamespace = @"^(?<function>[0-9a-zA-Z_]+\.[0-9a-zA-Z_]+\s*\()";
+        private static readonly Regex CompiledRegexPatternFunctionWithNamespace = new Regex(
+            RegexPatternFunctionWithNamespace, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternSyntaxSuger_AL = @"^\.@@(?<direction>(B|F))";
+        private static readonly Regex CompiledRegexPatternSyntaxSuger_AL = new Regex(
+            RegexPatternSyntaxSuger_AL, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
 
         private string Value { get; set; } = "";
         private int ValueInt32 { get; set; } = default(int);
@@ -324,7 +377,7 @@ namespace AILZ80ASM.AILight
         /// <returns></returns>
         public static bool TryParseFormula(ref string target, out string resultFormula)
         {
-            var matchOperation = Regex.Match(target, RegexPatternOperation, RegexOptions.IgnoreCase);
+            var matchOperation = CompiledRegexPatternOperation.Match(target);
             if (!matchOperation.Success)
             {
                 resultFormula = "";
@@ -332,7 +385,7 @@ namespace AILZ80ASM.AILight
             }
 
             // 記号のみチェック
-            var matchSymbol = Regex.Match(target, RegexPatternSymbolOperation, RegexOptions.IgnoreCase);
+            var matchSymbol = CompiledRegexPatternSymbolOperation.Match(target);
             if (matchSymbol.Success)
             {
                 resultFormula = matchSymbol.Groups["operation"].Value;
@@ -341,7 +394,7 @@ namespace AILZ80ASM.AILight
             }
 
             // 文字列演算子のチェック
-            if (!Regex.IsMatch(target, $"{RegexPatternWordOperation}($|\\s+)", RegexOptions.IgnoreCase))
+            if (!CompiledRegexPatternWordOperation.IsMatch(target))
             {
                 resultFormula = "";
                 return false;
@@ -360,7 +413,7 @@ namespace AILZ80ASM.AILight
                 
                 if (!string.IsNullOrEmpty(nextTarget))
                 {
-                    var matchNextSymbol = Regex.Match(nextTarget, RegexPatternSymbolOperation, RegexOptions.IgnoreCase);
+                    var matchNextSymbol = CompiledRegexPatternSymbolOperation.Match(nextTarget);
                     if (matchNextSymbol.Success)
                     {
                         var operationType = OperationTypeTable[matchNextSymbol.Groups["operation"].Value.ToLower()];
@@ -407,12 +460,12 @@ namespace AILZ80ASM.AILight
         {
             var functionName = default(string);
 
-            var matched = Regex.Match(target, RegexPatternFunction, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            var matched = CompiledRegexPatternFunction.Match(target);
             if (matched.Success)
             {
                 functionName = matched.Groups["function"].Value;
             }
-            var matchedWithNamespace = Regex.Match(target, RegexPatternFunctionWithNamespace, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            var matchedWithNamespace = CompiledRegexPatternFunctionWithNamespace.Match(target);
             if (matchedWithNamespace.Success)
             {
                 functionName = matchedWithNamespace.Groups["function"].Value;
@@ -472,7 +525,7 @@ namespace AILZ80ASM.AILight
         /// <returns></returns>
         public static bool TryParseSyntaxSuger(ref string target, out string[] resultValues)
         {
-            var matched = Regex.Match(target, RegexPatternSyntaxSuger_AL, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            var matched = CompiledRegexPatternSyntaxSuger_AL.Match(target);
             if (matched.Success)
             {
                 var direction = matched.Groups["direction"].Value;
@@ -503,7 +556,7 @@ namespace AILZ80ASM.AILight
         /// <returns></returns>
         public static bool TryParseValue(ref string target, out string resultValue)
         { 
-            var matched = Regex.Match(target, RegexPatternValue, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            var matched = CompiledRegexPatternValue.Match(target);
             if (matched.Success)
             {
                 resultValue = matched.Groups["value"].Value;
@@ -1901,9 +1954,9 @@ namespace AILZ80ASM.AILight
         {
             var matched = default(Match);
 
-            if ((matched = Regex.Match(value, RegexPatternHexadecimal_HD, RegexOptions.Singleline | RegexOptions.IgnoreCase)).Success ||
-                (matched = Regex.Match(value, RegexPatternHexadecimal_HX, RegexOptions.Singleline | RegexOptions.IgnoreCase)).Success ||
-                (matched = Regex.Match(value, RegexPatternHexadecimal_TH, RegexOptions.Singleline | RegexOptions.IgnoreCase)).Success)
+            if ((matched = CompiledRegexPatternHexadecimal_HD.Match(value)).Success ||
+                (matched = CompiledRegexPatternHexadecimal_HX.Match(value)).Success ||
+                (matched = CompiledRegexPatternHexadecimal_TH.Match(value)).Success)
             {
                 result = matched.Groups["value"].Value.Replace("_", "");
                 return true;
@@ -1923,9 +1976,9 @@ namespace AILZ80ASM.AILight
         {
             var matched = default(Match);
 
-            if ((matched = Regex.Match(value, RegexPatternBinaryNumber_HB, RegexOptions.Singleline | RegexOptions.IgnoreCase)).Success ||
-                (matched = Regex.Match(value, RegexPatternBinaryNumber_TB, RegexOptions.Singleline | RegexOptions.IgnoreCase)).Success ||
-                (matched = Regex.Match(value, RegexPatternBinaryNumber_HP, RegexOptions.Singleline | RegexOptions.IgnoreCase)).Success)
+            if ((matched = CompiledRegexPatternBinaryNumber_HB.Match(value)).Success ||
+                (matched = CompiledRegexPatternBinaryNumber_TB.Match(value)).Success ||
+                (matched = CompiledRegexPatternBinaryNumber_HP.Match(value)).Success)
             {
                 result = matched.Groups["value"].Value.Replace("_", "");
                 return true;
@@ -1946,8 +1999,8 @@ namespace AILZ80ASM.AILight
         {
             var matched = default(Match);
 
-            if ((matched = Regex.Match(value, RegexPatternOctal_HO, RegexOptions.Singleline | RegexOptions.IgnoreCase)).Success ||
-                (matched = Regex.Match(value, RegexPatternOctal_TO, RegexOptions.Singleline | RegexOptions.IgnoreCase)).Success)
+            if ((matched = CompiledRegexPatternOctal_HO.Match(value)).Success ||
+                (matched = CompiledRegexPatternOctal_TO.Match(value)).Success)
             {
                 result = matched.Groups["value"].Value.Replace("_", "");
                 return true;
@@ -1968,8 +2021,8 @@ namespace AILZ80ASM.AILight
         {
             var matched = default(Match);
 
-            if ((matched = Regex.Match(value, RegexPatternDigit_N, RegexOptions.Singleline | RegexOptions.IgnoreCase)).Success ||
-                (matched = Regex.Match(value, RegexPatternDigit_D, RegexOptions.Singleline | RegexOptions.IgnoreCase)).Success)
+            if ((matched = CompiledRegexPatternDigit_N.Match(value)).Success ||
+                (matched = CompiledRegexPatternDigit_D.Match(value)).Success)
             {
                 result = matched.Groups["value"].Value.Replace("_", "");
                 return true;

--- a/AILZ80ASM/OperationItems/OperationItemData.cs
+++ b/AILZ80ASM/OperationItems/OperationItemData.cs
@@ -33,7 +33,18 @@ namespace AILZ80ASM.OperationItems
         }
 
         private static readonly string RegexPatternDataFunction = @"^\[(?<variable>[a-z|A-Z|0-9|_]+)\s*=\s*(?<start>[a-z|A-Z|0-9|_|$|%]+)\s*\.\.\s*(?<end>[a-z|A-Z|0-9|_|$|%]+)\s*:\s*(?<operation>.+)\]$";
+        private static readonly Regex CompiledRegexPatternDataFunction = new Regex(
+            RegexPatternDataFunction, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
+        private static readonly Regex RegexPatternDataFunction2 = new Regex(
+            RegexPatternDataFunction, RegexOptions.Compiled
+        );
+
         private static readonly string RegexPatternDataOP = @"(?<op1>^\S+)?\s*(?<op2>.+)*";
+        private static readonly Regex CompiledRegexPatternDataOP = new Regex(
+            RegexPatternDataOP, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
+
 
         private string[] ValueStrings { get; set; }
         private DataTypeEnum DataType { get; set; }
@@ -53,7 +64,7 @@ namespace AILZ80ASM.OperationItems
 
         public static OperationItemData Create(LineItem lineItem, AsmLoad asmLoad)
         {
-            var matched = Regex.Match(lineItem.OperationString, RegexPatternDataOP, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            var matched = CompiledRegexPatternDataOP.Match(lineItem.OperationString);
             var dataType = default(DataTypeEnum);
 
             var op1 = matched.Groups["op1"].Value;
@@ -98,7 +109,7 @@ namespace AILZ80ASM.OperationItems
                     }
 
                 }
-                else if (Regex.IsMatch(item.Value, RegexPatternDataFunction))
+                else if (RegexPatternDataFunction2.IsMatch(item.Value))
                 {
                     ValueList.AddRange(DBDW_Function(item.Value, lineDetailExpansionItemOperation, AsmLoad).Select(m => new DataValue { DataValueType = DataValueTypeEnum.StringValue, StringValue = m }));
                 }
@@ -247,7 +258,7 @@ namespace AILZ80ASM.OperationItems
         {
             var returnValues = new List<string>();
 
-            var matchFunction = Regex.Match(op, RegexPatternDataFunction, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            var matchFunction = CompiledRegexPatternDataFunction.Match(op);
             if (matchFunction.Success)
             {
                 var variableName = matchFunction.Groups["variable"].Value.Trim();
@@ -265,7 +276,7 @@ namespace AILZ80ASM.OperationItems
                 {
                     //ループの展開
                     var tmpOperation = Regex.Replace(operation, $"\\b{variableName}\\b", $"{currentValue}", RegexOptions.Singleline | RegexOptions.IgnoreCase);
-                    if (Regex.IsMatch(tmpOperation, RegexPatternDataFunction))
+                    if (RegexPatternDataFunction2.IsMatch(tmpOperation))
                     {
                         returnValues.AddRange(DBDW_Function(tmpOperation, lineDetailExpansionItemOperation, asmLoad));
                     }


### PR DESCRIPTION
issue #322 に関して正規表現の部分をコンパイル済み正規表現にして高速化してみました。

- OperationItems.cs の修正で、dbを使ったときの速度は高速化しました。
  - 手元の環境では、dbの8000行が2.9sから0.9sになっています。
- 自作のプログラムのアセンブルをしたところ、まだ時間がかかっていたので、影響の大きそうな AIName.cs も同様に修正したところ高速化しました。


C#はHello Worldしかやったことなく流儀を知らず、AI頼みの修正になっているのでこれで良いかわかりませんが、プルリクエストをお送りします。 
ビルドも、よく理解していないのですが、 `dotnet build `でビルドして動作させ、`dotnet test` でテストも通っているように思います。


失礼な点があればご容赦ください。