### PR TITLE
[issues-333] E0001のエラーメッセージが分かりづらい

### DIFF
--- a/AILZ80ASM.Test/AILZ80ASM.Test.csproj
+++ b/AILZ80ASM.Test/AILZ80ASM.Test.csproj
@@ -364,10 +364,19 @@
     <None Update="Test\Issues\327\Test.Z80">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Test\Issues\333\Test.ERR">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Test\Issues\334\Test.LST">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Test\Issues\334\Test.Z80">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Test\Issues\333\Test.LST">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Test\Issues\333\Test.Z80">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Test\Issues\336\Test.LST">

--- a/AILZ80ASM.Test/Test/Issues/333/Test.ERR
+++ b/AILZ80ASM.Test/Test/Issues/333/Test.ERR
@@ -1,0 +1,37 @@
+﻿*** AILZ80ASM *** Z-80 Assembler, version 1.0.21.0
+Copyright (C) 2024 by M.Ishino (AILight)
+
+# Inputs
+
+- Z80 filename [Test.Z80]
+
+# Assemble Status
+
+- Expand       (1/6)
+- PreAssemble  (2/6)
+- AdjAssemble  (3/6)
+- MainAssemble (4/6)
+- Validate     (5/6)
+- Complete     (6/6)
+
+# Outputs
+
+- LST filename [Issue333.LST]: Successful
+- BIN filename [Issue333.BIN]: Failed
+
+# Error
+
+Test.Z80:9  E0004: 演算、もしくはラベルの解決に失敗しました。定義を確認してください。[数値と数値の間には演算子が必要です]
+Test.Z80:10  E0004: 演算、もしくはラベルの解決に失敗しました。定義を確認してください。[数値と数値の間には演算子が必要です]
+Test.Z80:11  E0004: 演算、もしくはラベルの解決に失敗しました。定義を確認してください。[数値と数値の間には演算子が必要です]
+Test.Z80:12  E0001: 無効な命令が指定されました。ラベルに記号(,)が含まれています。
+
+# List
+
+Issue333.LST:10  E0004: 演算、もしくはラベルの解決に失敗しました。定義を確認してください。[数値と数値の間には演算子が必要です]
+Issue333.LST:11  E0004: 演算、もしくはラベルの解決に失敗しました。定義を確認してください。[数値と数値の間には演算子が必要です]
+Issue333.LST:12  E0004: 演算、もしくはラベルの解決に失敗しました。定義を確認してください。[数値と数値の間には演算子が必要です]
+Issue333.LST:13  E0001: 無効な命令が指定されました。ラベルに記号(,)が含まれています。
+
+4 error(s), 0 warning(s), 0 information
+

--- a/AILZ80ASM.Test/Test/Issues/333/Test.LST
+++ b/AILZ80ASM.Test/Test/Issues/333/Test.LST
@@ -1,0 +1,15 @@
+﻿                                ;*** AILZ80ASM *** Z-80 Assembler, version 1.0.21.0, LST:Full:4
+000000 8000                         ORG $8000
+                                
+       8000                     ABC:
+000000 8000 3E00             7      LD A, 0
+       8002                     .TEST1
+000002 8002 0600             7      LD B, 0
+                                
+000004 8004 CD0280          17      CALL ABC.TEST1
+000007 8007 **** E0004 **** 17      CALL ABC. TEST1
+00000A 800A **** E0004 **** 17      CALL ABC .TEST1
+00000D 800D **** E0004 **** 17      CALL ABC . TEST1
+            **** E0001 ****         CALL ABC,TEST1
+000010 8010 C9              10      RET
+[EOF:Test.Z80:UTF_8]

--- a/AILZ80ASM.Test/Test/Issues/333/Test.Z80
+++ b/AILZ80ASM.Test/Test/Issues/333/Test.Z80
@@ -1,0 +1,13 @@
+﻿	ORG $8000
+
+ABC:
+    LD A, 0
+.TEST1
+    LD B, 0
+
+    CALL ABC.TEST1
+    CALL ABC. TEST1
+    CALL ABC .TEST1
+    CALL ABC . TEST1
+    CALL ABC,TEST1
+    RET

--- a/AILZ80ASM.Test/Z80ZZIssueTest.cs
+++ b/AILZ80ASM.Test/Z80ZZIssueTest.cs
@@ -312,6 +312,15 @@ namespace AILZ80ASM.Test
         }
 
         [TestMethod]
+        public void Issue_333()
+        {
+            var result = Program.Main(@"Test.Z80", "-f", "-bin", "Issue333.BIN", "-lst", "Issue333.LST", "-err", "Issue333.ERR", "-cd", "./Test/Issues/333");
+            Assert.AreEqual(1, result);
+            Lib.AreSameLst(File.OpenRead("./Test/Issues/333/Issue333.LST"), File.OpenRead("./Test/Issues/333/Test.LST"), Assembler.AsmEnum.FileTypeEnum.LST);
+            Lib.AreSameLst(File.OpenRead("./Test/Issues/333/Issue333.ERR"), File.OpenRead("./Test/Issues/333/Test.ERR"), Assembler.AsmEnum.FileTypeEnum.ERR);
+        }
+
+        [TestMethod]
         public void Issue_334()
         {
             Lib.Assemble_AreSame(Path.Combine("Issues", "334"));

--- a/AILZ80ASM/Assembler/SyntaxErrorAdvisor.cs
+++ b/AILZ80ASM/Assembler/SyntaxErrorAdvisor.cs
@@ -1,0 +1,38 @@
+﻿using AILZ80ASM.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace AILZ80ASM.Assembler
+{
+    public static class SyntaxErrorAdvisor
+    {
+        private static readonly string RegexPatternSeparatorPattern = @"\b(?<FullMatch>[^\s]+,[^\s]+)\b";
+        private static readonly Regex CompiledRegexPatternSeparatorPattern = new Regex(
+            RegexPatternSeparatorPattern, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
+
+        public static void AnalyzeLine(LineItem lineItem, AsmLoad asmLoad)
+        {
+            InternalAnalyzeLineForLabel(lineItem, asmLoad);
+        }
+
+        private static void InternalAnalyzeLineForLabel(LineItem lineItem, AsmLoad asmLoad)
+        {
+            var matched = CompiledRegexPatternSeparatorPattern.Match(lineItem.OperationString);
+            if (matched.Success)
+            {
+                var matchedString = matched.Groups["FullMatch"].Value;
+                var replacedString = matchedString.Replace(" ", "").Replace(",", ".");
+
+                if (asmLoad.FindLabel(replacedString) != default)
+                {
+                    throw new ErrorAssembleException(Error.ErrorCodeEnum.E0001, "ラベルに記号(,)が含まれています。");
+                }
+            }
+        }
+    }
+}

--- a/AILZ80ASM/LineDetailItems/LineDetailItemMacro.cs
+++ b/AILZ80ASM/LineDetailItems/LineDetailItemMacro.cs
@@ -101,6 +101,9 @@ namespace AILZ80ASM.LineDetailItems
                     }
                 }
 
+                // エラーを調査する
+                SyntaxErrorAdvisor.AnalyzeLine(this.LineItem, this.AsmLoad);
+                
                 // マクロが見つからないケースは、エラーとする
                 throw new ErrorAssembleException(Error.ErrorCodeEnum.E0001, errorMessage);
             }


### PR DESCRIPTION
## チケット
[[issues-333] https://github.com/AILight/AILZ80ASM/issues/333](https://github.com/AILight/AILZ80ASM/issues/333)

## 対応内容
- ラベルに「,」が使われていた時に検出する機能を追加した