### PR TITLE
アセンブル速度の高速化

### DIFF
--- a/AILZ80ASM/AILight/AIMath.cs
+++ b/AILZ80ASM/AILight/AIMath.cs
@@ -100,9 +100,9 @@ namespace AILZ80ASM.AILight
                     // ラベル演算子を処理する
                     var operations = new List<AIValue>();
                     var labelName = item.OriginalValue;
-                    while (AIMath.LabelOperatorStrings.Any(m => labelName.EndsWith(m, StringComparison.CurrentCultureIgnoreCase)))
+                    int atmarkIndex;
+                    while ((atmarkIndex = labelName.LastIndexOf(".@")) >= 0 && AIMath.LabelOperatorStrings.Any(m => labelName.EndsWith(m, StringComparison.CurrentCultureIgnoreCase)))
                     {
-                        var atmarkIndex = labelName.LastIndexOf(".@");
                         var operation = labelName.Substring(atmarkIndex);
                         labelName = labelName.Substring(0, atmarkIndex);
                         var notFound = true;

--- a/AILZ80ASM/AILight/AIMath.cs
+++ b/AILZ80ASM/AILight/AIMath.cs
@@ -12,7 +12,15 @@ namespace AILZ80ASM.AILight
     public static class AIMath
     {
         private static readonly string RegexPatternCharMap = @"^((?<charMap>@.*\:)\s*|)(""|')";
+        private static readonly Regex CompiledRegexPatternCharMap = new Regex(
+            RegexPatternCharMap, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+
+        );
+
         private static readonly string RegexPatternCharMapLabel = @"^((?<charMap>@.*\:)(?<label>[a-zA-Z0-9_]+))";
+        private static readonly Regex CompiledRegexPatternCharMapLabel = new Regex(
+            RegexPatternCharMapLabel, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
 
         public static string[] LabelOperatorStrings => LabelOperatorDic.SelectMany(m => m.Value).ToArray();
         public static Dictionary<string, string[]> LabelOperatorDic => new Dictionary<string, string[]>
@@ -248,7 +256,7 @@ namespace AILZ80ASM.AILight
 
         private static bool TryParseString(ref string tmpValue, out string resultString)
         {
-            var matched = Regex.Match(tmpValue, RegexPatternCharMap, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            var matched = CompiledRegexPatternCharMap.Match(tmpValue);
             if (matched.Success)
             {
                 var stringCheck = tmpValue;
@@ -274,7 +282,7 @@ namespace AILZ80ASM.AILight
             else
             {
                 // ラベルを使ってのCharMap指定
-                var matchedLabel = Regex.Match(tmpValue, RegexPatternCharMapLabel, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+                var matchedLabel = CompiledRegexPatternCharMapLabel.Match(tmpValue);
                 if (matchedLabel.Success)
                 {
                     resultString = matchedLabel.Value;

--- a/AILZ80ASM/Assembler/Label.cs
+++ b/AILZ80ASM/Assembler/Label.cs
@@ -43,11 +43,29 @@ namespace AILZ80ASM.Assembler
         }
 
         private static readonly string RegexPatternGlobalLabel = @"^\[(?<label>([a-zA-Z0-9!-/:-@\[-~]+))\]";
+        private static readonly Regex CompiledRegexPatternGlobalLabel = new Regex(
+                RegexPatternGlobalLabel, RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternLabel = @"(?<label>(^[a-zA-Z0-9!-/:-@\[-~]+)):+";
+        private static readonly Regex CompiledRegexPatternLabel = new Regex(
+                RegexPatternLabel, RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternSubLabel = @"(?<label>(^\.[a-zA-Z0-9!-/;-@\[-~]+:*))(\s+|$)";
+        private static readonly Regex CompiledRegexPatternSubLabel = new Regex(
+                RegexPatternSubLabel, RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternValueLabel1 = @"(?<label>(^[a-zA-Z0-9!-/:-@\[-~]+:*))\s+(" + String.Join('|', AsmReservedWord.GetReservedWordsForLabel().Select(m => m.Name)) + @")\s+(?<value>(.+))";
+        private static readonly Regex CompiledRegexPatternValueLabel1 = new Regex(
+                RegexPatternValueLabel1, RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternValueLabel2 = @"(?<label>(^[a-zA-Z0-9!-/:-@\[-~]+\.[a-zA-Z0-9!-/:-@\[-~]+:*))\s+(" + String.Join('|', AsmReservedWord.GetReservedWordsForLabel().Select(m => m.Name)) + @")\s+(?<value>(.+))";
+        private static readonly Regex CompiledRegexPatternValueLabel2 = new Regex(
+                RegexPatternValueLabel2, RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
         private static readonly string RegexPatternValueLabel3 = @"(?<label>(^[a-zA-Z0-9!-/:-@\[-~]+)):?\s*equ";
+        private static readonly Regex CompiledRegexPatternValueLabel3 = new Regex(
+                RegexPatternValueLabel3, RegexOptions.Singleline | RegexOptions.IgnoreCase
+        );
 
         public string GlobalLabelName { get; private set; }
         public string LabelName { get; private set; }
@@ -245,12 +263,12 @@ namespace AILZ80ASM.Assembler
 
         public static string GetLabelText(string lineString)
         {
-            var matchedGlobalLabel = Regex.Match(lineString, RegexPatternGlobalLabel, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            var matchedGlobalLabel = CompiledRegexPatternGlobalLabel.Match(lineString);
             if (matchedGlobalLabel.Success)
             {
                 return "[" + matchedGlobalLabel.Groups["label"].Value + "]";
             }
-            var matchedLabel = Regex.Match(lineString, RegexPatternLabel, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            var matchedLabel = CompiledRegexPatternLabel.Match(lineString);
             if (matchedLabel.Success)
             {
                 var label = matchedLabel.Groups["label"].Value;
@@ -262,24 +280,24 @@ namespace AILZ80ASM.Assembler
 
                 return lineString.Substring(0, startIndex);
             }
-            var matchedSubLabel = Regex.Match(lineString, RegexPatternSubLabel, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            var matchedSubLabel = CompiledRegexPatternSubLabel.Match(lineString);
             if (matchedSubLabel.Success)
             {
                 return matchedSubLabel.Groups["label"].Value;
             }
-            var matchedValueLabel1 = Regex.Match(lineString, RegexPatternValueLabel1, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            var matchedValueLabel1 = CompiledRegexPatternValueLabel1.Match(lineString);
             if (matchedValueLabel1.Success && !AsmReservedWord.GetReservedWordsForLabel().Any(m => string.Compare(m.Name, matchedValueLabel1.Groups["label"].Value, true) == 0))
             {
                 return matchedValueLabel1.Groups["label"].Value;
             }
 
-            var matchedValueLabel2 = Regex.Match(lineString, RegexPatternValueLabel2, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            var matchedValueLabel2 = CompiledRegexPatternValueLabel2.Match(lineString);
             if (matchedValueLabel2.Success && !AsmReservedWord.GetReservedWordsForLabel().Any(m => string.Compare(m.Name, matchedValueLabel2.Groups["label"].Value, true) == 0))
             {
                 return matchedValueLabel2.Groups["label"].Value;
             }
 
-            var matchedValueLabel3 = Regex.Match(lineString, RegexPatternValueLabel3, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            var matchedValueLabel3 = CompiledRegexPatternValueLabel3.Match(lineString);
             if (matchedValueLabel3.Success)
             {
                 // equの時には、ラベル指定可能にする
@@ -501,7 +519,7 @@ namespace AILZ80ASM.Assembler
 
         public static bool IsGlobalLabel(string labelString)
         {
-            return Regex.IsMatch(labelString, RegexPatternGlobalLabel);
+            return CompiledRegexPatternGlobalLabel.IsMatch(labelString);
         }
     }
 }

--- a/AILZ80ASM/Assembler/Label.cs
+++ b/AILZ80ASM/Assembler/Label.cs
@@ -417,10 +417,10 @@ namespace AILZ80ASM.Assembler
         /// <returns></returns>
         private static string RemoveOperators(string labelName)
         {
-            while (AIMath.LabelOperatorStrings.Any(m => labelName.EndsWith(m, StringComparison.CurrentCultureIgnoreCase)))
+            // while (labelName.LastIndexOf(".@") > 0 && AIMath.LabelOperatorStrings.Any(m => labelName.EndsWith(m, StringComparison.CurrentCultureIgnoreCase)))
+            int atmarkIndex;
+            while ((atmarkIndex = labelName.LastIndexOf(".@")) >= 0 && AIMath.LabelOperatorStrings.Any(m => labelName.EndsWith(m, StringComparison.CurrentCultureIgnoreCase)))
             {
-                var atmarkIndex = labelName.LastIndexOf(".@");
-
                 labelName = labelName.Substring(0, atmarkIndex);
             }
 


### PR DESCRIPTION
いくつか高速化の修正を加えました。
お時間あるときにご確認願います。

- AIMath.csの正規表現コンパイル
  -  3割ほど高速化
- Labels.csの正規表現コンパイル
  - これはあまり差がでませんでした。
- AIMath.csとLabels.csの ".@"の演算子のチェックの文字列検索順序を変更
  - 4割ほど高速化

参考に、```AILZ80ASM.Benchmark\bin\Release\net8.0\AILZ80ASM.Benchmark.exe```の実行結果をつけておきます。

CPU: i5-13400  

この修正

```
// * Summary *

BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.4169/23H2/2023Update/SunValley3)
13th Gen Intel Core i5-13400, 1 CPU, 16 logical and 10 physical cores
.NET SDK 8.0.304
  [Host]     : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX2


| Method     | Mean     | Error   | StdDev  |
|----------- |---------:|--------:|--------:|
| Benchmark1 | 746.3 ms | 8.12 ms | 7.59 ms |
```

v1.0.22

```
// * Summary *

BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.4169/23H2/2023Update/SunValley3)
13th Gen Intel Core i5-13400, 1 CPU, 16 logical and 10 physical cores
.NET SDK 8.0.304
  [Host]     : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX2


| Method     | Mean    | Error    | StdDev   |
|----------- |--------:|---------:|---------:|
| Benchmark1 | 1.623 s | 0.0244 s | 0.0228 s |
```