### PR TITLE
[issues-415] "\\0"が00Hに化ける

### DIFF
--- a/AILZ80ASM.Test/AIStringTest.cs
+++ b/AILZ80ASM.Test/AIStringTest.cs
@@ -244,65 +244,26 @@ namespace AILZ80ASM.Test
         }
 
         [TestMethod]
-        public void GetBytesByStringTest()
+        [DataRow(new byte[] { 0x41 }, "\"A\"")]
+        [DataRow(new byte[] { 0x90, 0xCE, 0x96, 0xEC }, "\"石野\"")]
+        [DataRow(new byte[] { 0x90, 0xCE, 0x96, 0xEC }, "@SJIS:\"石野\"")]
+        [DataRow(new byte[] { 0x5C, 0x30, 0x30, 0x30, 0x30 }, "\"\\\\0000\"")]
+        [DataRow(new byte[] { 0x41 }, "'A'")]
+        [DataRow(new byte[] { 0x90, 0xCE, 0x96, 0xEC }, "'石野'")]
+        [DataRow(new byte[] { 0x90, 0xCE, 0x96, 0xEC }, "@SJIS:'石野'")]
+        [DataRow(new byte[] { 0x5C, 0x30, 0x30, 0x30, 0x30 }, "'\\\\0000'")]
+        [DataRow(new byte[] { 0x41 }, "\'A\'")]
+        [DataRow(new byte[] { 0x90, 0xCE, 0x96, 0xEC }, "\'石野\'")]
+        [DataRow(new byte[] { 0x90, 0xCE, 0x96, 0xEC }, "@SJIS:\'石野\'")]
+        [DataRow(new byte[] { 0x5C, 0x30, 0x30, 0x30, 0x30 }, "\'\\\\0000\'")]
+        public void GetBytesByStringTest(byte[] expected, string target)
         {
-            // ダブルクオーテーション
-            {
-                var asmLoad = new AsmLoad(new AsmOption(), new InstructionSet.Z80());
+            var asmLoad = new AsmLoad(new AsmOption(), new InstructionSet.Z80());
 
-                var bytes = AIString.GetBytesByString("\"A\"", asmLoad);
-                Assert.AreEqual(0x41, bytes[0]);
-            }
+            var actual = AIString.GetBytesByString(target, asmLoad);
 
+            CollectionAssert.AreEqual(expected, actual);
 
-            {
-                var asmLoad = new AsmLoad(new AsmOption(), new InstructionSet.Z80());
-
-                var bytes = AIString.GetBytesByString("\"石野\"", asmLoad);
-                Assert.AreEqual(0x90, bytes[0]);
-                Assert.AreEqual(0xCE, bytes[1]);
-                Assert.AreEqual(0x96, bytes[2]);
-                Assert.AreEqual(0xEC, bytes[3]);
-            }
-
-            {
-                var asmLoad = new AsmLoad(new AsmOption(), new InstructionSet.Z80());
-
-                var bytes = AIString.GetBytesByString("@SJIS:\"石野\"", asmLoad);
-                Assert.AreEqual(0x90, bytes[0]);
-                Assert.AreEqual(0xCE, bytes[1]);
-                Assert.AreEqual(0x96, bytes[2]);
-                Assert.AreEqual(0xEC, bytes[3]);
-            }
-
-
-            // シングルクオーテーション
-            {
-                var asmLoad = new AsmLoad(new AsmOption(), new InstructionSet.Z80());
-
-                var bytes = AIString.GetBytesByString("\'A\'", asmLoad);
-                Assert.AreEqual(0x41, bytes[0]);
-            }
-
-            {
-                var asmLoad = new AsmLoad(new AsmOption(), new InstructionSet.Z80());
-
-                var bytes = AIString.GetBytesByString("\'石野\'", asmLoad);
-                Assert.AreEqual(0x90, bytes[0]);
-                Assert.AreEqual(0xCE, bytes[1]);
-                Assert.AreEqual(0x96, bytes[2]);
-                Assert.AreEqual(0xEC, bytes[3]);
-            }
-
-            {
-                var asmLoad = new AsmLoad(new AsmOption(), new InstructionSet.Z80());
-
-                var bytes = AIString.GetBytesByString("@SJIS:\'石野\'", asmLoad);
-                Assert.AreEqual(0x90, bytes[0]);
-                Assert.AreEqual(0xCE, bytes[1]);
-                Assert.AreEqual(0x96, bytes[2]);
-                Assert.AreEqual(0xEC, bytes[3]);
-            }
         }
 
         [TestMethod]

--- a/AILZ80ASM/AILight/AIString.cs
+++ b/AILZ80ASM/AILight/AIString.cs
@@ -80,10 +80,11 @@ namespace AILZ80ASM.AILight
         public static string EscapeSequence(string target)
         {
             // エスケープシーケンスの置き換え
-            foreach (var item in EscapeSequenceCharTables)
+            try
             {
-                target = target.Replace(item[0], item[1]);
+                target = Regex.Unescape(target);
             }
+            catch { }
 
             return target;
         }


### PR DESCRIPTION
## チケット
[[issues-415] "\\0"が00Hに化ける](https://github.com/AILight/AILZ80ASM/issues/415)

## 対応内容
- エスケープシーケンスの処理を改良した