### PR TITLE
アセンブル速度高速化(v1.0.29)

### DIFF
--- a/AILZ80ASM/AILight/AIMath.cs
+++ b/AILZ80ASM/AILight/AIMath.cs
@@ -114,7 +114,7 @@ namespace AILZ80ASM.AILight
                         {
                             foreach (var shortHand in labelOperation.Value)
                             {
-                                if (string.Compare(operation, shortHand, true) == 0)
+                                if (string.Equals(operation, shortHand, StringComparison.OrdinalIgnoreCase))
                                 {
                                     operations.Add(new AIValue(labelOperation.Key, AIValue.ValueTypeEnum.Operation));
                                     notFound = false;

--- a/AILZ80ASM/AILight/AIValue.cs
+++ b/AILZ80ASM/AILight/AIValue.cs
@@ -1052,12 +1052,12 @@ namespace AILZ80ASM.AILight
                 ValueInt32Type = ValueInt32TypeEnum.Hex;
                 ValueInt32 = (int)asmAddress.Value.Output;
             }
-            else if (string.Compare(Value, "#TRUE", true) == 0)
+            else if (string.Equals(Value, "#TRUE", StringComparison.OrdinalIgnoreCase))
             {
                 ValueType = ValueTypeEnum.Bool;
                 ValueBool = true;
             }
-            else if (string.Compare(Value, "#FALSE", true) == 0)
+            else if (string.Equals(Value, "#FALSE", StringComparison.OrdinalIgnoreCase))
             {
                 ValueType = ValueTypeEnum.Bool;
                 ValueBool = false;

--- a/AILZ80ASM/Assembler/AsmLoad.cs
+++ b/AILZ80ASM/Assembler/AsmLoad.cs
@@ -240,12 +240,12 @@ namespace AILZ80ASM.Assembler
             if (label.LabelLevel == Label.LabelLevelEnum.GlobalLabel)
             {
                 // ラベルと同じ名前は付けられない
-                if (this.Scope.Labels.Any(m => string.Compare(m.LabelName, label.LabelFullName, true) == 0))
+                if (this.Scope.Labels.Any(m => string.Equals(m.LabelName, label.LabelFullName, StringComparison.OrdinalIgnoreCase))))
                 {
                     throw new ErrorAssembleException(Error.ErrorCodeEnum.E0017, label.LabelFullName);
                 }
 
-                if (!this.Scope.GlobalLabelNames.Any(m => string.Compare(m, label.LabelFullName, true) == 0))
+                if (!this.Scope.GlobalLabelNames.Any(m => string.Equals(m, label.LabelFullName, StringComparison.OrdinalIgnoreCase))))
                 {
                     // ネームスペースが変わるときには保存する
                     this.Scope.GlobalLabelNames.Add(label.LabelFullName);
@@ -257,7 +257,7 @@ namespace AILZ80ASM.Assembler
             else
             {
                 // ネームスペースとと同じ名前は付けられない
-                if (this.Scope.GlobalLabelNames.Any(m => string.Compare(m, label.LabelName, true) == 0))
+                if (this.Scope.GlobalLabelNames.Any(m => string.Equals(m, label.LabelName, StringComparison.OrdinalIgnoreCase))))
                 {
                     throw new ErrorAssembleException(Error.ErrorCodeEnum.E0018, label.LabelName);
                 }
@@ -322,7 +322,7 @@ namespace AILZ80ASM.Assembler
 
             foreach (var label in this.Scope.Labels.Where(m => m.LabelLevel != Label.LabelLevelEnum.GlobalLabel))
             {
-                var originalLabel = originalLabels.FirstOrDefault(m => string.Compare(m.LabelFullName, label.LabelFullName, true) == 0);
+                var originalLabel = originalLabels.FirstOrDefault(m => string.Equals(m.LabelFullName, label.LabelFullName, StringComparison.OrdinalIgnoreCase)));
                 if (originalLabel == default)
                 {
                     // 一致しない場合
@@ -415,12 +415,12 @@ namespace AILZ80ASM.Assembler
             if (label.LabelLevel == Label.LabelLevelEnum.GlobalLabel)
             {
                 // ラベルと同じ名前は付けられない
-                if (this.Scope.Labels.Any(m => string.Compare(m.LabelName, label.LabelFullName, true) == 0))
+                if (this.Scope.Labels.Any(m => string.Equals(m.LabelName, label.LabelFullName, StringComparison.OrdinalIgnoreCase))))
                 {
                     throw new ErrorAssembleException(Error.ErrorCodeEnum.E0017, label.LabelFullName);
                 }
 
-                if (!this.Scope.GlobalLabelNames.Any(m => string.Compare(m, label.LabelFullName, true) == 0))
+                if (!this.Scope.GlobalLabelNames.Any(m => string.Equals(m, label.LabelFullName, StringComparison.OrdinalIgnoreCase))))
                 {
                     // ネームスペースが変わるときには保存する
                     this.Scope.GlobalLabelNames.Add(label.LabelFullName);
@@ -431,7 +431,7 @@ namespace AILZ80ASM.Assembler
             else
             {
                 // ネームスペースとと同じ名前は付けられない
-                if (this.Scope.GlobalLabelNames.Any(m => string.Compare(m, label.LabelName, true) == 0))
+                if (this.Scope.GlobalLabelNames.Any(m => string.Equals(m, label.LabelName, StringComparison.OrdinalIgnoreCase))))
                 {
                     throw new ErrorAssembleException(Error.ErrorCodeEnum.E0018, label.LabelName);
                 }
@@ -453,7 +453,7 @@ namespace AILZ80ASM.Assembler
         /// <exception cref="ErrorAssembleException"></exception>
         public void AddFunction(Function function)
         {
-            if (this.Scope.Functions.Any(m => string.Compare(m.FullName, function.FullName, true) == 0))
+            if (this.Scope.Functions.Any(m => string.Equals(m.FullName, function.FullName, StringComparison.OrdinalIgnoreCase))))
             {
                 throw new ErrorAssembleException(Error.ErrorCodeEnum.E4001);
             }
@@ -467,7 +467,7 @@ namespace AILZ80ASM.Assembler
         /// <exception cref="ErrorAssembleException"></exception>
         public void AddMacro(Macro macro)
         {
-            if (this.Scope.Macros.Any(m => string.Compare(m.FullName, macro.FullName, true) == 0))
+            if (this.Scope.Macros.Any(m => string.Equals(m.FullName, macro.FullName, StringComparison.OrdinalIgnoreCase))))
             {
                 throw new ErrorAssembleException(Error.ErrorCodeEnum.E3010);
             }
@@ -535,7 +535,7 @@ namespace AILZ80ASM.Assembler
 
             while (targetAsmLoad != default)
             {
-                var name = targetAsmLoad.Scope.GlobalLabelNames.Where(m => string.Compare(m, target, true) == 0).FirstOrDefault();
+                var name = targetAsmLoad.Scope.GlobalLabelNames.Where(m => string.Equals(m, target, StringComparison.OrdinalIgnoreCase))).FirstOrDefault();
                 if (name != default)
                 {
                     return name;
@@ -569,7 +569,7 @@ namespace AILZ80ASM.Assembler
                     while (targetAsmLoad != default)
                     {
                         var labelFullName = Label.GetLabelFullName(target, targetAsmLoad);
-                        var scopelabels = targetAsmLoad.Scope.Labels.Where(m => string.Compare(m.LabelFullName, labelFullName, true) == 0);
+                        var scopelabels = targetAsmLoad.Scope.Labels.Where(m => string.Equals(m.LabelFullName, labelFullName, StringComparison.OrdinalIgnoreCase));
                         var label = scopelabels.FirstOrDefault();
                         if (label != default)
                         {
@@ -588,7 +588,7 @@ namespace AILZ80ASM.Assembler
                         while (targetAsmLoad != default)
                         {
                             var labelFullName = Label.GetLabelFullName(target, targetAsmLoad);
-                            var scopelabels = targetAsmLoad.Scope.Labels.Where(m => string.Compare(m.LabelFullName, labelFullName, true) == 0);
+                            var scopelabels = targetAsmLoad.Scope.Labels.Where(m => string.Equals(m.LabelFullName, labelFullName, StringComparison.OrdinalIgnoreCase));
                             var label = scopelabels.FirstOrDefault();
                             if (label != default)
                             {
@@ -605,9 +605,9 @@ namespace AILZ80ASM.Assembler
                         {
                             var labelFullName = Label.GetLabelFullName(target, targetAsmLoad);
                             var labelNames = labelFullName.Split(".");
-                            var scopelabels = targetAsmLoad.Scope.Labels.Where(m => string.Compare(m.GlobalLabelName, labelNames[0], true) == 0 &&
-                                                                               string.Compare(m.LabelName, labelNames[1], true) == 0 &&
-                                                                               string.Compare(m.TmpLabelName, labelNames[3], true) == 0);
+                            var scopelabels = targetAsmLoad.Scope.Labels.Where(m => string.Equals(m.GlobalLabelName, labelNames[0], StringComparison.OrdinalIgnoreCase) &&
+                                                                               string.Equals(m.LabelName, labelNames[1], StringComparison.OrdinalIgnoreCase) &&
+                                                                               string.Equals(m.TmpLabelName, labelNames[3], StringComparison.OrdinalIgnoreCase));
 
                             if (scopelabels.Count() > 0)
                             {
@@ -684,7 +684,7 @@ namespace AILZ80ASM.Assembler
             while (targetAsmLoad != default)
             {
                 var longFunctionName = Function.GetFunctionFullName(target, targetAsmLoad);
-                var function = targetAsmLoad.Scope.Functions.Where(m => string.Compare(m.FullName, longFunctionName, true) == 0).FirstOrDefault();
+                var function = targetAsmLoad.Scope.Functions.Where(m => string.Equals(m.FullName, longFunctionName, StringComparison.OrdinalIgnoreCase))).FirstOrDefault();
                 if (function != default)
                 {
                     return function;
@@ -702,7 +702,7 @@ namespace AILZ80ASM.Assembler
 
             while (targetAsmLoad != default)
             {
-                var macros = targetAsmLoad.Scope.Macros.Where(m => string.Compare(m.Name, shortMacroName, true) == 0).ToArray();
+                var macros = targetAsmLoad.Scope.Macros.Where(m => string.Equals(m.Name, shortMacroName, StringComparison.OrdinalIgnoreCase))).ToArray();
                 if (macros != default)
                 {
                     return macros;
@@ -719,7 +719,7 @@ namespace AILZ80ASM.Assembler
             while (targetAsmLoad != default)
             {
                 var longMacroName = Macro.GetMacroFullName(target, targetAsmLoad);
-                var function = targetAsmLoad.Scope.Macros.Where(m => string.Compare(m.FullName, longMacroName, true) == 0).FirstOrDefault();
+                var function = targetAsmLoad.Scope.Macros.Where(m => string.Equals(m.FullName, longMacroName, StringComparison.OrdinalIgnoreCase))).FirstOrDefault();
                 if (function != default)
                 {
                     return function;

--- a/AILZ80ASM/InstructionSet/ISA.cs
+++ b/AILZ80ASM/InstructionSet/ISA.cs
@@ -34,7 +34,7 @@ namespace AILZ80ASM.InstructionSet
         /// <returns></returns>
         public bool IsMatchRegisterName(string target)
         {
-            return InstructionSet.RegisterAndFlagNames.Where(m => string.Compare(m, target, true) == 0).Any();
+            return InstructionSet.RegisterAndFlagNames.Where(m => string.Equals(m, target, StringComparison.OrdinalIgnoreCase)).Any();
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace AILZ80ASM.InstructionSet
         /// <returns></returns>
         public bool IsMatchInstructionName(string target)
         {
-            return InstructionSet.InstructionNames.Where(m => string.Compare(m, target, true) == 0).Any();
+            return InstructionSet.InstructionNames.Where(m => string.Equals(m, target, StringComparison.OrdinalIgnoreCase)).Any();
         }
 
 
@@ -111,7 +111,7 @@ namespace AILZ80ASM.InstructionSet
                     assembleResult.InstructionItem.InstructionRegisterDic[key].InstructionRegisterMode == InstructionRegister.InstructionRegisterModeEnum.Register)
                 {
                     var instructionRegister = assembleResult.InstructionItem.InstructionRegisterDic[key];
-                    var instructionRegisterItem = instructionRegister.InstructionRegisterItems.First(m => string.Compare(m.RegisterName, value, true) == 0);
+                    var instructionRegisterItem = instructionRegister.InstructionRegisterItems.First(m => string.Equals(m.RegisterName, value, StringComparison.OrdinalIgnoreCase));
                     replaceDic.Add(instructionRegister.MnemonicBitName, instructionRegisterItem.BitCode);
                 }
                 else if (assembleResult.InstructionItem.InstructionValueDic.ContainsKey(value))


### PR DESCRIPTION
今回も高速化をして15%弱改善してみました。この辺になると100ms未満のわずかな時間差でしかないですが、よろしければご確認ください。

後の二つのコミット（AIMath, AIValueの修正）はBenchmarkで差が誤差レベルでしたが、損はないのかと思って一応含めましたが修正しなくても良いかもしれません。

## 参考値

- 一応私の環境でのBenchmark結果です。
- 10msくらいは、同じバージョンでも測定毎に差が発生しました。

```
------------------------------------------
v1.0.28

// * Summary *

BenchmarkDotNet v0.13.12, Windows 11 (10.0.26100.3775)
13th Gen Intel Core i5-13400, 1 CPU, 16 logical and 10 physical cores
.NET SDK 9.0.203
  [Host]     : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2


| Method     | Mean     | Error    | StdDev   |
|----------- |---------:|---------:|---------:|
| Benchmark1 | 725.3 ms | 11.43 ms | 10.69 ms |

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  1 ms   : 1 Millisecond (0.001 sec)

// ***** BenchmarkRunner: End *****
Run time: 00:00:20 (20.98 sec), executed benchmarks: 1

Global total time: 00:00:24 (24.76 sec), executed benchmarks: 1
// * Artifacts cleanup *
Artifacts cleanup is finished

------------------------------------------
v1.0.29
4266f62

// * Summary *

BenchmarkDotNet v0.13.12, Windows 11 (10.0.26100.3775)
13th Gen Intel Core i5-13400, 1 CPU, 16 logical and 10 physical cores
.NET SDK 9.0.203
  [Host]     : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2


| Method     | Mean     | Error    | StdDev  |
|----------- |---------:|---------:|--------:|
| Benchmark1 | 711.6 ms | 10.17 ms | 9.01 ms |

// * Hints *
Outliers
  Benchmark.Benchmark1: Default -> 1 outlier  was  removed (748.84 ms)

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  1 ms   : 1 Millisecond (0.001 sec)

// ***** BenchmarkRunner: End *****
Run time: 00:00:20 (20.51 sec), executed benchmarks: 1

Global total time: 00:00:37 (37.87 sec), executed benchmarks: 1



------------------------------------------
AsmLoAsmLoad.csのCompareをEqualsに変更
006437b

// * Summary *

BenchmarkDotNet v0.13.12, Windows 11 (10.0.26100.3775)
13th Gen Intel Core i5-13400, 1 CPU, 16 logical and 10 physical cores
.NET SDK 9.0.203
  [Host]     : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2


| Method     | Mean     | Error   | StdDev  |
|----------- |---------:|--------:|--------:|
| Benchmark1 | 668.9 ms | 8.53 ms | 7.98 ms |

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  1 ms   : 1 Millisecond (0.001 sec)

// ***** BenchmarkRunner: End *****
Run time: 00:00:19 (19.75 sec), executed benchmarks: 1

Global total time: 00:00:35 (35.51 sec), executed benchmarks: 1


------------------------------------------
ISA.csのCompareをEqualsに変更
0ec5c62

// * Summary *

BenchmarkDotNet v0.13.12, Windows 11 (10.0.26100.3775)
13th Gen Intel Core i5-13400, 1 CPU, 16 logical and 10 physical cores
.NET SDK 9.0.203
  [Host]     : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2


| Method     | Mean     | Error    | StdDev   |
|----------- |---------:|---------:|---------:|
| Benchmark1 | 616.4 ms | 11.92 ms | 17.10 ms |

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  1 ms   : 1 Millisecond (0.001 sec)

// ***** BenchmarkRunner: End *****
Run time: 00:00:27 (27.34 sec), executed benchmarks: 1

Global total time: 00:00:43 (43.04 sec), executed benchmarks: 1

------------------------------------------
AIValue.csのCompareをEqualsに変更
d2b27332d579e0

// * Summary *

BenchmarkDotNet v0.13.12, Windows 11 (10.0.26100.3775)
13th Gen Intel Core i5-13400, 1 CPU, 16 logical and 10 physical cores
.NET SDK 9.0.203
  [Host]     : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2


| Method     | Mean     | Error    | StdDev  |
|----------- |---------:|---------:|--------:|
| Benchmark1 | 618.8 ms | 10.33 ms | 9.16 ms |

// * Hints *
Outliers
  Benchmark.Benchmark1: Default -> 1 outlier  was  removed (657.62 ms)

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  1 ms   : 1 Millisecond (0.001 sec)

// ***** BenchmarkRunner: End *****
Run time: 00:00:19 (19.17 sec), executed benchmarks: 1

Global total time: 00:00:35 (35 sec), executed benchmarks: 1


------------------------------------------
AIMath.csのCompareをEqualsに変更
44265a5

// * Summary *

BenchmarkDotNet v0.13.12, Windows 11 (10.0.26100.3775)
13th Gen Intel Core i5-13400, 1 CPU, 16 logical and 10 physical cores
.NET SDK 9.0.203
  [Host]     : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2


| Method     | Mean     | Error   | StdDev  |
|----------- |---------:|--------:|--------:|
| Benchmark1 | 618.5 ms | 8.72 ms | 8.16 ms |

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  1 ms   : 1 Millisecond (0.001 sec)

// ***** BenchmarkRunner: End *****
Run time: 00:00:19 (19.17 sec), executed benchmarks: 1

Global total time: 00:00:34 (34.92 sec), executed benchmarks: 1
// * Artifacts cleanup *
```

