### PR TITLE
[issues-429] 出力形式指定の ShortCut Option にファイル名引数を指定するとアセンブルできない

### DIFF
--- a/AILZ80ASM.Test/CommandLineTest.cs
+++ b/AILZ80ASM.Test/CommandLineTest.cs
@@ -250,6 +250,23 @@ namespace AILZ80ASM.Test
                 Assert.AreEqual(1, outputFiles.Count);
                 Assert.AreEqual("Main.bin", outputFiles[AsmEnum.FileTypeEnum.BIN].Name);
             }
+
+            {
+                var rootCommand = AsmCommandLine.SettingRootCommand();
+                var arguments = new[] { "-bin", "Main.bin", "-i", "Main.z80" };
+
+                Assert.IsTrue(rootCommand.Parse(arguments));
+                var fileInfos = rootCommand.GetValue<FileInfo[]>("input");
+
+                Assert.AreEqual(1, fileInfos.Length);
+                Assert.AreEqual("Main.z80", fileInfos.First().Name);
+                Assert.AreEqual("Main.bin", rootCommand.GetValue<FileInfo>("output").Name);
+                Assert.AreEqual("bin", rootCommand.GetValue<string>("outputMode"));
+
+                var outputFiles = rootCommand.GetOutputFiles();
+                Assert.AreEqual(1, outputFiles.Count);
+                Assert.AreEqual("Main.bin", outputFiles[AsmEnum.FileTypeEnum.BIN].Name);
+            }
         }
 
         [TestMethod]

--- a/AILZ80ASM/CommandLine/RootCommand.cs
+++ b/AILZ80ASM/CommandLine/RootCommand.cs
@@ -257,7 +257,6 @@ namespace AILZ80ASM.CommandLine
             // デフォルトパラメーターを取得
             var defineOptionalOption = Options.FirstOrDefault(m => m.IsDefineOptional);
 
-
             foreach (var value in args)
             {
                 if (value.StartsWith('-') && !helpMode)
@@ -300,14 +299,16 @@ namespace AILZ80ASM.CommandLine
                 {
                     helpMode = false;
                     // デフォルトの宣言対応
-                    if (key == default && defineOptionalOption != default)
+                    if (saveParameter == default(Parameter))
                     {
-                        key = defineOptionalOption;
-                        result.Add(key, new List<string>());
+                        if (key == default && defineOptionalOption != default)
+                        {
+                            key = defineOptionalOption;
+                            result.Add(key, new List<string>());
+                        }
                     }
-
                     // パラメータ直後の値の場合は、オプションとのマッチを行う
-                    if (saveParameter != default)
+                    else
                     {
                         var option = Options.FirstOrDefault(m => m.Aliases.Contains(saveParameter.ShortCut));
                         if (option != default)

--- a/Check-Links.ps1
+++ b/Check-Links.ps1
@@ -81,7 +81,7 @@ foreach ($match in $matches) {
                 break  # 400以上ならリトライしない
             } catch {
                 if ($_.Exception.Response?.StatusCode.Value__ -eq 429) {
-                    Write-Host "  結果: 429 Too Many Requests - リトライ中 ($($retryCount + 1)/3) - メソッド: $method" -ForegroundColor Yellow
+                    Write-Host "  結果: 429 Too Many Requests - リトライ中 ($($retryCount + 1)/5) - メソッド: $method" -ForegroundColor Yellow
                     Start-Sleep -Seconds 5
                     $retryCount++
                 } else {


### PR DESCRIPTION
## チケット
[[issues-429] 出力形式指定の ShortCut Option にファイル名引数を指定するとアセンブルできない](https://github.com/AILight/AILZ80ASM/issues/429)

## 対応内容
- -iオプションの処理に問題があったので修正した