### PR TITLE
[issues-437] コマンドラインオプションで-vを指定するとエラーになっていないのに戻り値が2になる

### DIFF
--- a/AILZ80ASM.Test/Z80ZZIssueTest.cs
+++ b/AILZ80ASM.Test/Z80ZZIssueTest.cs
@@ -462,5 +462,19 @@ namespace AILZ80ASM.Test
         {
             Lib.Assemble_AreSame(Path.Combine("Issues", "416"));
         }
+
+        [TestMethod]
+        public void Issue_437()
+        {
+            {
+                var result = Program.Main(@"-v");
+                Assert.AreEqual(0, result);
+            }
+            {
+                var result = Program.Main(@"--version");
+                Assert.AreEqual(0, result);
+            }
+
+        }
     }
 }

--- a/AILZ80ASM/Program.cs
+++ b/AILZ80ASM/Program.cs
@@ -86,14 +86,15 @@ namespace AILZ80ASM
                         }
                     }
                 }
+                else if (rootCommand.GetSelected("version"))
+                {
+                    Trace.WriteLine(rootCommand.ParseMessage);
+                    return 0;
+                }
                 else
                 {
-                    if (!rootCommand.GetSelected("version"))
-                    {
-                        OutputStart();
-                    }
+                    OutputStart();
                     Trace.WriteLine(rootCommand.ParseMessage);
-
                     return 2;
                 }
             }


### PR DESCRIPTION
## チケット
[[issues-437] コマンドラインオプションで-vを指定するとエラーになっていないのに戻り値が2になる](https://github.com/AILight/AILZ80ASM/issues/437)

## 対応内容
- -vオプションの戻り値の設定に問題あった