### PR TITLE
アセンブル速度高速化

### DIFF
--- a/AILZ80ASM/Assembler/AsmLoad.cs
+++ b/AILZ80ASM/Assembler/AsmLoad.cs
@@ -535,7 +535,7 @@ namespace AILZ80ASM.Assembler
 
             while (targetAsmLoad != default)
             {
-                var name = targetAsmLoad.Scope.GlobalLabelNames.Where(m => string.Compare(m, target, true) == 0).FirstOrDefault();
+                var name = targetAsmLoad.Scope.GlobalLabelNames.Where(m => string.Equals(m, target, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
                 if (name != default)
                 {
                     return name;
@@ -569,7 +569,7 @@ namespace AILZ80ASM.Assembler
                     while (targetAsmLoad != default)
                     {
                         var labelFullName = Label.GetLabelFullName(target, targetAsmLoad);
-                        var scopelabels = targetAsmLoad.Scope.Labels.Where(m => string.Compare(m.LabelFullName, labelFullName, true) == 0);
+                        var scopelabels = targetAsmLoad.Scope.Labels.Where(m => string.Equals(m.LabelFullName, labelFullName, StringComparison.OrdinalIgnoreCase));
                         var label = scopelabels.FirstOrDefault();
                         if (label != default)
                         {
@@ -605,9 +605,9 @@ namespace AILZ80ASM.Assembler
                         {
                             var labelFullName = Label.GetLabelFullName(target, targetAsmLoad);
                             var labelNames = labelFullName.Split(".");
-                            var scopelabels = targetAsmLoad.Scope.Labels.Where(m => string.Compare(m.GlobalLabelName, labelNames[0], true) == 0 &&
-                                                                               string.Compare(m.LabelName, labelNames[1], true) == 0 &&
-                                                                               string.Compare(m.TmpLabelName, labelNames[3], true) == 0);
+                            var scopelabels = targetAsmLoad.Scope.Labels.Where(m => string.Equals(m.GlobalLabelName, labelNames[0], StringComparison.OrdinalIgnoreCase) &&
+                                                                               string.Equals(m.LabelName, labelNames[1], StringComparison.OrdinalIgnoreCase) &&
+                                                                               string.Equals(m.TmpLabelName, labelNames[3], StringComparison.OrdinalIgnoreCase));
 
                             if (scopelabels.Count() > 0)
                             {

--- a/AILZ80ASM/InstructionSet/ISA.cs
+++ b/AILZ80ASM/InstructionSet/ISA.cs
@@ -34,7 +34,7 @@ namespace AILZ80ASM.InstructionSet
         /// <returns></returns>
         public bool IsMatchRegisterName(string target)
         {
-            return InstructionSet.RegisterAndFlagNames.Where(m => string.Compare(m, target, true) == 0).Any();
+            return InstructionSet.RegisterAndFlagNamesSet?.Contains(target) ?? false;
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace AILZ80ASM.InstructionSet
         /// <returns></returns>
         public bool IsMatchInstructionName(string target)
         {
-            return InstructionSet.InstructionNames.Where(m => string.Compare(m, target, true) == 0).Any();
+            return InstructionSet.InstructionNamesSet?.Contains(target) ?? false;
         }
 
 

--- a/AILZ80ASM/InstructionSet/InstructionSet.cs
+++ b/AILZ80ASM/InstructionSet/InstructionSet.cs
@@ -11,10 +11,10 @@ namespace AILZ80ASM.InstructionSet
     {
         public char NumberReplaseChar { get; set; }
         public char[] SplitChars { get; set; }
-        public string[] RegisterAndFlagNames { get; set; }
+        public HashSet<string> RegisterAndFlagNamesSet { get; set; }
         public InstructionRegister[] InstructionRegisters { get; set; }
         public InstructionItem[] InstructionItems { get; set; }
-        public string[] InstructionNames { get; set; }
+        public HashSet<string> InstructionNamesSet { get; set; }
         public Dictionary<string, InstructionItem[]> InstructionDic { get; set; } = new();
 
         public void MakeDataSet()
@@ -41,7 +41,7 @@ namespace AILZ80ASM.InstructionSet
                 InstructionDic.Add(item.Key, item.Value.ToArray());
             }
 
-            InstructionNames = instructionList.Distinct().ToArray();
+            InstructionNamesSet = new HashSet<string>(instructionList.Distinct(), StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/AILZ80ASM/InstructionSet/Z80.cs
+++ b/AILZ80ASM/InstructionSet/Z80.cs
@@ -15,7 +15,7 @@ namespace AILZ80ASM.InstructionSet
         {
             NumberReplaseChar = '$',
             SplitChars = new[] { ' ', ',' , '+', '(', ')' },
-            RegisterAndFlagNames = RegisterAndFlagNames,
+            RegisterAndFlagNamesSet = new HashSet<string>(RegisterAndFlagNames, StringComparer.OrdinalIgnoreCase),
             InstructionRegisters = new[]
             {
                 new InstructionRegister


### PR DESCRIPTION
アセンブル速度高速化しました。ベンチマーク上は10%程度早くなっています。

-  CompareをEqualに変更
- InstructionSetとRegisterAndFlagNamesのハッシュ化

私の環境でのベンチマーク結果も参考に載せます。
あと、コミットには入れていませんが、dotnet 10にするとさらに10%程度早くなりました。
参考までにそのベンチマークも載せておきます。

また、お時間のあるときに、よろしくお願いいたします。

## AILZ80ASM.Benchmark

### dotnet 8

```
mainブランチ 既存速度

 // * Summary *

BenchmarkDotNet v0.13.12, Windows 11 (10.0.26200.7462)
13th Gen Intel Core i5-13400, 1 CPU, 16 logical and 10 physical cores
.NET SDK 10.0.101
  [Host]     : .NET 8.0.22 (8.0.2225.52707), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.22 (8.0.2225.52707), X64 RyuJIT AVX2


| Method     | Mean     | Error    | StdDev   |
|----------- |---------:|---------:|---------:|
| Benchmark1 | 698.7 ms | 13.69 ms | 15.77 ms |

// * Hints *
Outliers
  Benchmark.Benchmark1: Default -> 1 outlier  was  removed (760.11 ms)

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  1 ms   : 1 Millisecond (0.001 sec)

// ***** BenchmarkRunner: End *****
Run time: 00:00:22 (22.86 sec), executed benchmarks: 1

Global total time: 00:00:40 (40.08 sec), executed benchmarks: 1
// * Artifacts cleanup *
Artifacts cleanup is finished


-----------------------------
修正版
commit: "eb8f5c22d50d1b487fff278924d2d1d4cfff4c94"

// * Summary *

BenchmarkDotNet v0.13.12, Windows 11 (10.0.26200.7462)
13th Gen Intel Core i5-13400, 1 CPU, 16 logical and 10 physical cores
.NET SDK 10.0.101
  [Host]     : .NET 8.0.22 (8.0.2225.52707), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.22 (8.0.2225.52707), X64 RyuJIT AVX2


| Method     | Mean     | Error    | StdDev  |
|----------- |---------:|---------:|--------:|
| Benchmark1 | 614.0 ms | 10.08 ms | 9.43 ms |

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  1 ms   : 1 Millisecond (0.001 sec)

// ***** BenchmarkRunner: End *****
Run time: 00:00:19 (19.96 sec), executed benchmarks: 1

Global total time: 00:00:37 (37.21 sec), executed benchmarks: 1
// * Artifacts cleanup *
Artifacts cleanup is finished
```

### dotnet 10

```
// * Summary *

BenchmarkDotNet v0.13.12, Windows 11 (10.0.26200.7462)
13th Gen Intel Core i5-13400, 1 CPU, 16 logical and 10 physical cores
.NET SDK 10.0.101
  [Host]     : .NET 10.0.1 (10.0.125.57005), X64 RyuJIT AVX2
  DefaultJob : .NET 10.0.1 (10.0.125.57005), X64 RyuJIT AVX2


| Method     | Mean     | Error    | StdDev   |
|----------- |---------:|---------:|---------:|
| Benchmark1 | 540.9 ms | 10.76 ms | 12.81 ms |

// * Hints *
Outliers
  Benchmark.Benchmark1: Default -> 1 outlier  was  removed, 2 outliers were detected (506.11 ms, 580.34 ms)

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  1 ms   : 1 Millisecond (0.001 sec)

// ***** BenchmarkRunner: End *****
Run time: 00:00:21 (21.17 sec), executed benchmarks: 1

Global total time: 00:00:25 (25.56 sec), executed benchmarks: 1
// * Artifacts cleanup *
Artifacts cleanup is finished
```